### PR TITLE
update lftp version number

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -20,7 +20,7 @@ mktmpdir() {
 
 BUILD_DIR=$1
 CACHE_DIR=$2
-VERSION="4.5.2"
+VERSION="4.6.3a"
 LFTP_BUILD="$(mktmpdir lftp)"
 INSTALL_DIR="$BUILD_DIR/.heroku/vendor/lftp"
 PROFILE_PATH="$BUILD_DIR/.profile.d/lftp.sh"


### PR DESCRIPTION
Lftp version 4.5.2 is not available for download anymore. It causes compilation to fail.